### PR TITLE
Fix casing on require for GitHubClientException

### DIFF
--- a/client/GitHubClientBase.php
+++ b/client/GitHubClientBase.php
@@ -1,5 +1,5 @@
 <?php
-require_once(__DIR__ . '/GithubClientException.php');
+require_once(__DIR__ . '/GitHubClientException.php');
 
 abstract class GitHubClientBase
 {


### PR DESCRIPTION
Library crashes without fix
