### PR TITLE
json_encode $data in createComment

### DIFF
--- a/client/services/GitHubIssuesComments.php
+++ b/client/services/GitHubIssuesComments.php
@@ -52,7 +52,7 @@ class GitHubIssuesComments extends GitHubService
 		$data = array();
 		$data['body'] = $body;
 		
-		return $this->client->request("/repos/$owner/$repo/issues/$issue/comments", 'POST', $data, 201, 'GitHubIssueComment');
+		return $this->client->request("/repos/$owner/$repo/issues/$issue/comments", 'POST', json_encode($data), 201, 'GitHubIssueComment');
 	}
 	
 	/**


### PR DESCRIPTION
github response without json_encode was a 400 error:
{"message":"Problems parsing JSON","documentation_url":"https://developer.github.com/v3"}
