### PR TITLE
Make GitHubContributor extend GitHubUser

### DIFF
--- a/client/objects/GitHubContributor.php
+++ b/client/objects/GitHubContributor.php
@@ -4,7 +4,7 @@ require_once(__DIR__ . '/GitHubUser.php');
 
 	
 
-class GitHubContributor extends GitHubObject
+class GitHubContributor extends GitHubUser
 {
 	/* (non-PHPdoc)
 	 * @see GitHubObject::getAttributes()


### PR DESCRIPTION
`GitHubContributor` should extend `GitHubUser` instead of just `GitHubObject`.

This means that you can access details about the contributor as a user, such as their username and avatar.

Currently all you can do is list the number of contributions:

``` php
$contributors = $client->repos->listContributors($user, $repo);

foreach ($contributors as $contributor) {
    echo $contributor->getContributions() . "<br>";
}
```

Whereas with the change you can access their user information too:

``` php
$contributors = $client->repos->listContributors($user, $repo);

foreach ($contributors as $contributor) {
    echo $contributor->getLogin() . ': ' . $contributor->getContributions() . "<br>";
}
```
