### PR TITLE
Added GitHubPulls::isPullRequestMerged()

### DIFF
--- a/client/services/GitHubPulls.php
+++ b/client/services/GitHubPulls.php
@@ -104,5 +104,26 @@ class GitHubPulls extends GitHubService
 		return $this->client->request("/repos/$owner/$repo/pulls/$number/files", 'GET', $data, 200, 'GitHubFile', true);
 	}
 	
+	/**
+	 * Get if a pull request has been merged
+	 *
+	 * @return boolean
+	 */
+	public function isPullRequestMerged($owner, $repo, $number)
+	{
+		$merged = false;
+
+		try
+		{
+			$data = array();
+			$this->client->request("/repos/$owner/$repo/pulls/$number/merge", 'GET', $data, 204, '');
+			$merged = true;
+		}
+		catch ( GitHubClientException $e )
+		{
+		}
+
+		return $merged;
+	}
 }
 


### PR DESCRIPTION
The implementation is a bit different than the usual auto-generated code because it will return a boolean result instead of returning NULL upon a successful response or throwing an exception on failure.
