### PR TITLE
Added parent attribute for forked repositories

### DIFF
--- a/client/objects/GitHubRepo.php
+++ b/client/objects/GitHubRepo.php
@@ -30,7 +30,7 @@ class GitHubRepo extends GitHubSimpleRepo
 			'pushed_at' => 'string',
 			'created_at' => 'string',
 			'updated_at' => 'string',
-			'parent' => 'GitHubFullRepo',
+			'parent' => 'GitHubSimpleRepo',
 		));
 	}
 	

--- a/client/objects/GitHubRepo.php
+++ b/client/objects/GitHubRepo.php
@@ -30,6 +30,7 @@ class GitHubRepo extends GitHubSimpleRepo
 			'pushed_at' => 'string',
 			'created_at' => 'string',
 			'updated_at' => 'string',
+			'parent' => 'GitHubFullRepo',
 		));
 	}
 	
@@ -122,6 +123,11 @@ class GitHubRepo extends GitHubSimpleRepo
 	 * @var string
 	 */
 	protected $updated_at;
+
+	/**
+	 * @var GitHubFullRepo
+	*/
+	protected $parent;
 
 	/**
 	 * @return string
@@ -265,6 +271,14 @@ class GitHubRepo extends GitHubSimpleRepo
 	public function getUpdatedAt()
 	{
 		return $this->updated_at;
+	}
+
+	/**
+	 * @return GitHubFullRepo
+	*/
+	public function getParent()
+	{
+		return $this->parent;
 	}
 
 }


### PR DESCRIPTION
The parent attribute, which shows up for forked repositories, was not available.