### PR TITLE
Support for web-based Oauth

### DIFF
--- a/client/GitHubClientBase.php
+++ b/client/GitHubClientBase.php
@@ -380,8 +380,8 @@ abstract class GitHubClientBase
 			}
 		}
 
-		if($status !== $expectedHttpCode)
-			throw new GitHubClientException("Expected status [$expectedHttpCode], actual status [$status], URL [$url]", GitHubClientException::INVALID_HTTP_CODE);
+		if((is_array($expectedHttpCode) && !in_array($status, $expectedHttpCode)) || (!is_array($expectedHttpCode) && $status !== $expectedHttpCode))
+			throw new GitHubClientException("Expected status [" . (is_array($expectedHttpCode) ? implode(', ', $expectedHttpCode) : $expectedHttpCode) . "], actual status [$status], URL [$url]", GitHubClientException::INVALID_HTTP_CODE);
 		
 		if ( $returnType == 'string' )
 			return implode("\n", $content);

--- a/client/services/GitHubOauth.php
+++ b/client/services/GitHubOauth.php
@@ -10,15 +10,111 @@ class GitHubOauth extends GitHubService
 {
 
 	/**
-	 * Web Application Flow
+	 * List your authorizations
+	 * 
+	 * @return array<GitHubOauthAccess>
+	 */
+	public function listYourAuthorizations()
+	{
+		$data = array();
+		
+		return $this->client->request("/authorizations", 'GET', $data, 200, 'GitHubOauthAccess', true);
+	}
+	
+	/**
+	 * Get a single authorization
 	 * 
 	 * @return GitHubOauthAccess
 	 */
-	public function webApplicationFlow($id)
+	public function getAingleAuthorization($id)
 	{
 		$data = array();
 		
 		return $this->client->request("/authorizations/$id", 'GET', $data, 200, 'GitHubOauthAccess');
+	}
+	
+	/**
+	 * Create a new authorization
+	 * 
+	 * @param $scopes array (Optional) - Replaces the authorization scopes with these.
+	 * @param $note string (Optional) - A note to remind you what the OAuth token is for.
+	 * @param $note_url string (Optional) - A URL to remind you what app the OAuth token is for.
+	 * @param $client_id string (Optional) - The 20 character OAuth app client key for which to create the token.
+	 * @param $client_secret string (Optional) - The 40 character OAuth app client secret for which to create the token.
+	 * @param $fingerprint string (Optional) - A unique string to distinguish an authorization from others created for the same client ID and user.
+	 * @return GitHubOauthAccess
+	 */
+	public function createNewAuthorization($scopes = null, $note = null, $note_url = null, $client_id = null, $client_secret = null, $fingerprint = null)
+	{
+		$data = array();
+		if(!is_null($scopes))
+			$data['scopes'] = $scopes;
+		if(!is_null($note))
+			$data['note'] = $note;
+		if(!is_null($note_url))
+			$data['note_url'] = $note_url;
+		if(!is_null($client_id))
+			$data['client_id'] = $client_id;
+		if(!is_null($client_secret))
+			$data['client_secret'] = $client_secret;
+		if(!is_null($fingerprint))
+			$data['fingerprint'] = $fingerprint;
+		
+		return $this->client->request("/authorizations", 'POST', $data, 201, 'GitHubOauthAccess');
+	}
+	
+	/**
+	 * Get-or-create an authorization for a specific app
+	 * 
+	 * @param $scopes array (Optional) - Replaces the authorization scopes with these.
+	 * @param $note string (Optional) - A note to remind you what the OAuth token is for.
+	 * @param $note_url string (Optional) - A URL to remind you what app the OAuth token is for.
+	 * @param $client_id string (Optional) - The 20 character OAuth app client key for which to create the token.
+	 * @param $client_secret string (Optional) - The 40 character OAuth app client secret for which to create the token.
+	 * @param $fingerprint string (Optional) - A unique string to distinguish an authorization from others created for the same client ID and user.
+	 * @return GitHubOauthAccess
+	 */
+	public function getOrCreateAuthorizationForApp($scopes = null, $note = null, $note_url = null, $client_id = null, $client_secret = null, $fingerprint = null)
+	{
+		$data = array();
+		if(!is_null($scopes))
+			$data['scopes'] = $scopes;
+		if(!is_null($note))
+			$data['note'] = $note;
+		if(!is_null($note_url))
+			$data['note_url'] = $note_url;
+		if(!is_null($client_secret))
+			$data['client_secret'] = $client_secret;
+		if(!is_null($fingerprint))
+			$data['fingerprint'] = $fingerprint;
+		
+		return $this->client->request("/authorizations/clients/$client_id", 'PUT', $data, array(200, 201), 'GitHubOauthAccess');
+	}
+	
+	/**
+	 * Get-or-create an authorization for a specific app and fingerprint
+	 * 
+	 * @param $scopes array (Optional) - Replaces the authorization scopes with these.
+	 * @param $note string (Optional) - A note to remind you what the OAuth token is for.
+	 * @param $note_url string (Optional) - A URL to remind you what app the OAuth token is for.
+	 * @param $client_id string (Optional) - The 20 character OAuth app client key for which to create the token.
+	 * @param $client_secret string (Optional) - The 40 character OAuth app client secret for which to create the token.
+	 * @param $fingerprint string (Optional) - A unique string to distinguish an authorization from others created for the same client ID and user.
+	 * @return GitHubOauthAccess
+	 */
+	public function getOrCreateAuthorizationForAppAndFingerprint($scopes = null, $note = null, $note_url = null, $client_id = null, $client_secret = null, $fingerprint = null)
+	{
+		$data = array();
+		if(!is_null($scopes))
+			$data['scopes'] = $scopes;
+		if(!is_null($note))
+			$data['note'] = $note;
+		if(!is_null($note_url))
+			$data['note_url'] = $note_url;
+		if(!is_null($client_secret))
+			$data['client_secret'] = $client_secret;
+		
+		return $this->client->request("/authorizations/clients/$client_id/$fingerprint", 'PUT', $data, array(200, 201), 'GitHubOauthAccess');
 	}
 	
 	/**
@@ -30,9 +126,10 @@ class GitHubOauth extends GitHubService
 	 * 	authorization.
 	 * @param $note string (Optional) - A note to remind you what the OAuth token is for.
 	 * @param $note_url string (Optional) - A URL to remind you what app the OAuth token is for.
+	 * @param $fingerprint string (Optional) - A unique string to distinguish an authorization from others created for the same client ID and user.
 	 * @return GitHubOauthAccess
 	 */
-	public function createNewAuthorization($id, $scopes = null, $add_scopes = null, $remove_scopes = null, $note = null, $note_url = null)
+	public function updateAuthorization($id, $scopes = null, $add_scopes = null, $remove_scopes = null, $note = null, $note_url = null, $fingerprint = null)
 	{
 		$data = array();
 		if(!is_null($scopes))
@@ -45,8 +142,22 @@ class GitHubOauth extends GitHubService
 			$data['note'] = $note;
 		if(!is_null($note_url))
 			$data['note_url'] = $note_url;
+		if(!is_null($fingerprint))
+			$data['fingerprint'] = $fingerprint;
 		
-		return $this->client->request("/authorizations/$id", 'PATCH', $data, 200, 'GitHubOauthAccess');
+		return $this->client->request("/authorizations/$id", 'PATCH', $data, 201, 'GitHubOauthAccess');
+	}
+	
+	/**
+	 * Reset an authorization
+	 * 
+	 * @return GitHubOauthAccess
+	 */
+	public function resetAuthorization($client_id, $access_token)
+	{
+		$data = array();
+		
+		return $this->client->request("/applications/$client_id/tokens/$access_token", 'POST', $data, 200, 'GitHubOauthAccess');
 	}
 	
 	/**
@@ -61,9 +172,31 @@ class GitHubOauth extends GitHubService
 	}
 	
 	/**
+	 * Revoke all authorizations for an application
+	 * 
+	 */
+	public function revokeAllAppAuthorizations($client_id)
+	{
+		$data = array();
+		
+		return $this->client->request("/applications/$client_id/tokens", 'DELETE', $data, 204, '');
+	}
+	
+	/**
+	 * Revoke an authorization for an application
+	 * 
+	 */
+	public function revokeAppAuthorization($client_id, $access_token)
+	{
+		$data = array();
+		
+		return $this->client->request("/applications/$client_id/tokens/$access_token", 'DELETE', $data, 204, '');
+	}
+	
+	/**
 	 * Check an authorization
 	 * 
-	 * @return array<GitHubOauthAccessWithUser>
+	 * @return GitHubOauthAccessWithUser
 	 */
 	public function checkAnAuthorization($client_id, $access_token)
 	{


### PR DESCRIPTION
New AuthType and the ability to set an oauth token - as per the following excerpt.  

```
        $client = new GitHubClient();
        // The following two methods are new additions
        $client->setAuthType( 'Oauth' );
        $client->setOauthToken( $oauth_token );
```
Before doing this, the web application will need to take the steps necessary to get the OAUTH token.  One example of this can be seen [in this issue](https://github.com/tan-tan-kanarek/github-php-client/issues/75)
