### PR TITLE
Implemented assigning multiple assignees to an issue

### DIFF
--- a/client/services/GitHubIssues.php
+++ b/client/services/GitHubIssues.php
@@ -153,26 +153,34 @@ class GitHubIssues extends GitHubService
 	 * 
 	 * @param $title string (Required) - The title of the issue.
 	 * @param $body string (Optional) - The contents of the issue.
-	 * @param $assignee string (Optional) - Login for the user that this issue should be assigned to.
+	 * @param $assignees array (Optional) of **strings** - Login(s) for the user(s) that this issue
+	 *  should be assigned to. Supplying a string here still works for backwards compatibility but
+	 *  will be removed in the future.
 	 * @param $milestone number (Optional) - Milestone to associate this issue with.
 	 * @param $labels array (Optional) of strings - Labels to associate with this issue. 
 	 * 	Pass one or more Labels to _replace_ the set of Labels on this Issue. 
 	 * 	Send an empty array (`[]`) to clear all Labels from the Issue.
 	 * @return GitHubIssue
 	 */
-	public function createAnIssue($owner, $repo, $title, $body = null, $assignee = null, $milestone = null, $labels = null)
+	public function createAnIssue($owner, $repo, $title, $body = null, $assignees = null, $milestone = null, $labels = null)
 	{
 		$data = array();
 		$data['title'] = $title;
 		if(!is_null($body))
 			$data['body'] = $body;
-		if(!is_null($assignee))
-			$data['assignee'] = $assignee;
 		if(!is_null($milestone))
 			$data['milestone'] = $milestone;
 		if(!is_null($labels))
 			$data['labels'] = $labels;
-		
+
+		if(!is_null($assignees)) {
+			if (is_string($assignees)) {
+				trigger_error('Assignees: supplying a string is deprecated, please supply an array of strings.', E_USER_DEPRECATED);
+				$assignees = array($assignees);
+			}
+			$data['assignees'] = $assignees;
+		}
+
 		$data = json_encode($data);
 		
 		return $this->client->request("/repos/$owner/$repo/issues", 'POST', $data, 201, 'GitHubIssue');
@@ -182,8 +190,9 @@ class GitHubIssues extends GitHubService
 	 * Edit an issue
 	 * 
 	 * @param $body string (Optional) - The contents of the issue.
-	 * @param $assignee string (Optional) - Login for the user that this issue should be
-	 * 	assigned to.
+	 * @param $assignees array (Optional) of **strings** - Login(s) for the user(s) that this issue
+	 *  should be assigned to. Supplying a string here still works for backwards compatibility but
+	 *  will be removed in the future.
 	 * @param $state string (Optional) - State of the issue: `open` or `closed`.
 	 * @param $milestone number (Optional) - Milestone to associate this issue with.
 	 * @param $labels array (Optional) of **strings** - Labels to associate with this
@@ -191,22 +200,31 @@ class GitHubIssues extends GitHubService
 	 * 	Issue. Send an empty array (`[]`) to clear all Labels from the Issue.
 	 * @return GitHubIssue
 	 */
-	public function editAnIssue($owner, $repo, $title, $number, $body = null, $assignee = null, $state = null, $milestone = null, $labels = null)
+	public function editAnIssue($owner, $repo, $title = null, $number, $body = null, $assignees = null, $state = null, $milestone = null, $labels = null)
 	{
 		$data = array();
-		$data['title'] = $title;
+		if(!is_null($title))
+			$data['title'] = $title;
 		if(!is_null($body))
 			$data['body'] = $body;
-		if(!is_null($assignee))
-			$data['assignee'] = $assignee;
 		if(!is_null($state))
 			$data['state'] = $state;
 		if(!is_null($milestone))
 			$data['milestone'] = $milestone;
 		if(!is_null($labels))
 			$data['labels'] = $labels;
-		
-		return $this->client->request("/repos/$owner/$repo/issues/$number", 'PATCH', json_encode($data), 200, 'GitHubIssue');
+
+		if(!is_null($assignees)) {
+			if (is_string($assignees)) {
+				trigger_error('Assignees: supplying a string is deprecated, please supply an array of strings.', E_USER_DEPRECATED);
+				$assignees = array($assignees);
+			}
+			$data['assignees'] = $assignees;
+		}
+
+		$data = json_encode($data);
+
+		return $this->client->request("/repos/$owner/$repo/issues/$number", 'PATCH', $data, 200, 'GitHubIssue');
 	}		
 	
 }


### PR DESCRIPTION
## What has been done

As per May 27th of 2016 Github [announced](https://developer.github.com/changes/2016-5-27-multiple-assignees/) that it's possible to assign multiple assignees via their API.

This PR implements that.

## Why

I use this library in [PRBot](https://github.com/Enrise/PRBot) and now had to resort to a custom API call via `$client->request()` in order to make use of the new API and assign multiple assignees.

## How to test

Create GitHub client, and edit an issue on a repo likes so:

```php
<?php

ini_set('display_errors', true);
ini_set('error_reporting', E_ALL);

require_once(__DIR__ . '/client/GitHubClient.php');

$client = new GitHubClient();

$client->setAuthType(GitHubClient::GITHUB_AUTH_TYPE_OAUTH_BASIC);
$client->setOauthKey('your-oauth-token');

$issue = $client->issues->editAnIssue(
    'SomeFork',
    'SomeRepo',
    null,
    123,
    null,
    ['tan-tan-kanarek', 'eXistenZNL']
);
```

This works, and for backwards compatibility reasons supplying a string also works:
```php
$issue = $client->issues->editAnIssue(
    'SomeFork',
    'SomeRepo',
    null,
    123,
    null,
    'tan-tan-kanarek'
);
```

but in this case a warning will be shown of level E_USER_DEPRECATED:

```sh
$ php test.php
PHP Deprecated:  Supplying a string is deprecated, please supply an array of strings. in /projects/github-php-client/client/services/GitHubIssues.php on line 219
```

## Some other things

I changed GitHubIssues::editAnIssue() so that $title is no longer mandatory. To prevent backwards compatibility breakage I did not change the order of the arguments, but this sadly means that you now have to supply `null`  as an argument twice.

This could be improved by moving the mandatory arguments to the left and the arguments that may be omited to the right, but would require releasing a new [major version](http://semver.org/).

## Questions and remarks

Just contact me, you know where to find me (-: