### PR TITLE
Changed expected return when adding collaborators

### DIFF
--- a/client/services/GitHubReposCollaborators.php
+++ b/client/services/GitHubReposCollaborators.php
@@ -27,7 +27,7 @@ class GitHubReposCollaborators extends GitHubService
 	{
 		$data = array();
 		
-		return $this->client->request("/repos/$owner/$repo/collaborators/$user", 'PUT', $data, 204, '');
+		return $this->client->request("/repos/$owner/$repo/collaborators/$user", 'PUT', $data, 201, '');
 	}
 	
 	/**


### PR DESCRIPTION
When you successfully add a collaborator on a repository, GitHub returns a 201 response, not a 204.