### PR TITLE
Add archived status to the repository object

### DIFF
--- a/client/objects/GitHubSimpleRepo.php
+++ b/client/objects/GitHubSimpleRepo.php
@@ -21,6 +21,7 @@ class GitHubSimpleRepo extends GitHubObject
 			'fork' => 'boolean',
 			'url' => 'string',
 			'html_url' => 'string',
+            'archived' => 'boolean'
 		));
 	}
 	
@@ -68,6 +69,11 @@ class GitHubSimpleRepo extends GitHubObject
 	 * @var string
 	 */
 	protected $html_url;
+
+    /**
+     * @var boolean
+     */
+    protected $archived;
 
 	/**
 	 * @return int
@@ -140,6 +146,14 @@ class GitHubSimpleRepo extends GitHubObject
 	{
 		return $this->html_url;
 	}
+
+    /**
+     * @return bool
+     */
+    public function getArchivedStatus()
+    {
+        return $this->archived;
+    }
 
 }
 


### PR DESCRIPTION
Hey there,

in some cases it could be quite necessary or come in handy if you could iterate through all your organization repositories while excluding the ones that are archived.
Therefore I added a function to see if the repository is archived.

The function returns a bool.

One could also name the function `isArchived()` if that works better.