### PR TITLE
implement functionality to get multiple assignees from an issue

### DIFF
--- a/client/objects/GitHubIssue.php
+++ b/client/objects/GitHubIssue.php
@@ -22,6 +22,7 @@ class GitHubIssue extends GitHubObject
 			'body' => 'string',
 			'user' => 'GitHubUser',
 			'assignee' => 'GitHubUser',
+            'assignees' => 'array<GitHubUser>',
 			'milestone' => 'GitHubMilestone',
 			'comments' => 'int',
 			'closed_at' => 'string',
@@ -70,6 +71,11 @@ class GitHubIssue extends GitHubObject
 	 * @var GitHubUser
 	 */
 	protected $assignee;
+
+    /**
+     * @var array<GitHubUser>
+     */
+    protected $assignees;
 
 	/**
 	 * @var GitHubMilestone
@@ -164,6 +170,14 @@ class GitHubIssue extends GitHubObject
 	{
 		return $this->assignee;
 	}
+
+    /**
+     * @return array<GitHubUser>
+     */
+    public function getAssignees()
+    {
+        return $this->assignees;
+    }
 
 	/**
 	 * @return GitHubMilestone


### PR DESCRIPTION
Hello @tan-tan-kanarek,

as I was using your github-php-client I noticed that there was no way to get multiple assignees from an issue.
There is an valid endpoint to return that information in the github-api: https://developer.github.com/v3/issues/#list-user-account-issues-assigned-to-the-authenticated-user

I implemented a function to get all the assigned users as array\<GitHubUser\> - Object.

Would be happy if you could merge that functionality for me.

Best Regards,

Frank.