### PR TITLE
Pull-Request: Add property labels to github issue object

### DIFF
--- a/client/objects/GitHubIssue.php
+++ b/client/objects/GitHubIssue.php
@@ -20,6 +20,7 @@ class GitHubIssue extends GitHubObject
 			'state' => 'string',
 			'title' => 'string',
 			'body' => 'string',
+            'labels' => 'array<GitHubLabel>',
 			'user' => 'GitHubUser',
 			'assignee' => 'GitHubUser',
             'assignees' => 'array<GitHubUser>',
@@ -61,6 +62,11 @@ class GitHubIssue extends GitHubObject
 	 * @var string
 	 */
 	protected $body;
+
+    /**
+     * @var array<GitHubLabel>
+     */
+    protected $labels;
 
 	/**
 	 * @var GitHubUser
@@ -154,6 +160,14 @@ class GitHubIssue extends GitHubObject
 	{
 		return $this->body;
 	}
+
+    /**
+     * @return array<GitHubLabel>
+     */
+    public function getLabels()
+    {
+        return $this->labels;
+    }
 
 	/**
 	 * @return GitHubUser


### PR DESCRIPTION
Hello again,

I found it to be very useful to get the labels assigned to the issues when requesting them.
Previously I had to do a workaround which basically did double the amount of api-calls.

It was something along the lines of:
```php
//get all issues assigned to authenticated user
$issues = $this->client->issues->listAllIssues();

//regex the repository out of the getUrl()
$repoName = preg_match($issue->getUrl(), ...);

//make another api call to list the labels on the issue
$this->client->issues->labels->listLabelsOnAnIssue($orga, $repoName, $issue->getNumber();
```

With the changes of the pull-request one could basically get all the needed informations about the labels when requesting the issues and does not have to make another api call.

Could you please merge this changes?

Thanks in advance!
