### PR TITLE
Extend GitHubLabel-Object with functionality to get the description

### DIFF
--- a/client/objects/GitHubLabel.php
+++ b/client/objects/GitHubLabel.php
@@ -2,60 +2,72 @@
 
 require_once(__DIR__ . '/../GitHubObject.php');
 
-	
+
 
 class GitHubLabel extends GitHubObject
 {
-	/* (non-PHPdoc)
-	 * @see GitHubObject::getAttributes()
-	 */
-	protected function getAttributes()
-	{
-		return array_merge(parent::getAttributes(), array(
-			'url' => 'string',
-			'name' => 'string',
-			'color' => 'string',
-		));
-	}
-	
-	/**
-	 * @var string
-	 */
-	protected $url;
+    /* (non-PHPdoc)
+     * @see GitHubObject::getAttributes()
+     */
+    protected function getAttributes()
+    {
+        return array_merge(parent::getAttributes(), array(
+            'url' => 'string',
+            'name' => 'string',
+            'color' => 'string',
+            'description' => 'string'
+        ));
+    }
 
-	/**
-	 * @var string
-	 */
-	protected $name;
+    /**
+     * @var string
+     */
+    protected $url;
 
-	/**
-	 * @var string
-	 */
-	protected $color;
+    /**
+     * @var string
+     */
+    protected $name;
 
-	/**
-	 * @return string
-	 */
-	public function getUrl()
-	{
-		return $this->url;
-	}
+    /**
+     * @var string
+     */
+    protected $color;
 
-	/**
-	 * @return string
-	 */
-	public function getName()
-	{
-		return $this->name;
-	}
+    /**
+     * @var string
+     */
+    protected $description;
 
-	/**
-	 * @return string
-	 */
-	public function getColor()
-	{
-		return $this->color;
-	}
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
 
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getColor()
+    {
+        return $this->color;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
 }
-


### PR DESCRIPTION
Hey there @tan-tan-kanarek,

i wanted to get the descriptions of labels while using your github-api-client.
I noticed that the GitHubLabel-Object does not provide the description attribute, so I added it and also an getter-function.

